### PR TITLE
WIP: Allowing a debug mode for testing

### DIFF
--- a/PNPros/ROS_bridge/pnp_ros/scripts/PNPActionServer.py
+++ b/PNPros/ROS_bridge/pnp_ros/scripts/PNPActionServer.py
@@ -86,6 +86,28 @@ def handle_PNPConditionValue(req):
     else:
         return PNPConditionValueResponse("None")
 
+def get_debug_actions(debug_config_path):
+    # checking if debug file exists 
+    if not os.path.exists(debug_config_path):
+        return {'Debug': False, 'msg': 'Debug file was not found.', 'value': {}}
+    with open(debug_config_path) as f:
+        debug_actions = yaml.safe_load(f) 
+    if debug_actions['Debug']['Active'] is False:
+        return {'Debug': False, 'msg': 'Debug mode is Not active.', 'value': {}}
+    mode = debug_actions['Debug']['Mode']
+    config = debug_actions['Configurations']
+    print('mode', mode)
+    print('config')
+    if mode not in config.keys():
+        return {'Debug': False, 'msg': 'Debug mode is not found in config file.', 'value': {}}
+    print('config[mode]', config[mode])
+    if config[mode]['Active'] in config[mode]:
+        return {'Debug': True, 'msg': 'Debug mode is active.', 'value': {'type':'enable_actions', 'data': config[mode]['Active']}}
+    if config[mode]['Inactive'] in config[mode]:
+        return {'Debug': True, 'msg': 'Debug mode is active.', 'value': {'type':'disable_actions', 'data': config[mode]['Inactive']}}
+    return {'Debug': False, 'msg': 'Debug mode did not find any actions.', 'value': {}}
+
+
 if __name__ == '__main__':
     rospy.init_node(NODE)
     rospy.set_param('robot_name', 'dummy')
@@ -95,6 +117,7 @@ if __name__ == '__main__':
 
     conditionManager = ConditionManager(conditions_folder)
     actionManager = ActionManager(actions_folder)
+    debugConfig = 
 
     # Service which returns truth value of condition
     rospy.Service(SRV_PNPCONDITIONEVAL,

--- a/PNPros/ROS_bridge/pnp_ros/scripts/PNPActionServer.py
+++ b/PNPros/ROS_bridge/pnp_ros/scripts/PNPActionServer.py
@@ -26,9 +26,6 @@ from pnp_msgs.srv import (
     PNPConditionValueResponse,
 )
 
-import yaml
-
-
 import pnp_common
 from pnp_common import *
 
@@ -107,72 +104,21 @@ def handle_PNPConditionValue(req):
         return PNPConditionValueResponse("None")
 
 
-def get_debug_actions(debug_config_path):
-    if not os.path.exists(debug_config_path):
-        return {"Debug": False, "msg": "Debug file was not found.", "value": {}}
-
-    with open(debug_config_path) as f:
-        debug_actions = yaml.safe_load(f)
-
-    if debug_actions["Debug"]["Active"] is False:
-        return {"Debug": False, "msg": "Debug mode is not active", "value": {}}
-
-    mode = debug_actions["Debug"]["Mode"]
-    config = debug_actions["Configurations"]
-
-    if mode not in config.keys():
-        return {
-            "Debug": False,
-            "msg": "Debug mode is not found in configurations",
-            "value": {},
-        }
-
-    if "Active" in config[mode].keys() and config[mode]["Active"] is not None:
-        return {
-            "Debug": True,
-            "msg": "Debug mode active",
-            "value": {
-                "mode": mode,
-                "type": "enable",
-                "actions": config[mode]["Active"],
-            },
-        }
-
-    if "Inactive" in config[mode].keys() and config[mode]["Inactive"] is not None:
-        return {
-            "Debug": True,
-            "msg": "Debug mode active",
-            "value": {
-                "mode": mode,
-                "type": "disable",
-                "actions": config[mode]["Inactive"],
-            },
-        }
-
-    # if no actions are found
-    return {"Debug": False, "msg": "Debug mode did not find any actions.", "value": {}}
-
-
 if __name__ == "__main__":
     rospy.init_node(NODE)
-    rospy.set_param('robot_name', 'dummy')
+    rospy.set_param("robot_name", "dummy")
 
     actions_folder = rospy.get_param("~actions_folder")
     conditions_folder = rospy.get_param("~conditions_folder")
 
     conditionManager = ConditionManager(conditions_folder)
     actionManager = ActionManager(actions_folder)
-    debugConfig =
 
     # Service which returns truth value of condition
-    rospy.Service(SRV_PNPCONDITIONEVAL,
-                  PNPCondition,
-                  handle_PNPConditionEval)
+    rospy.Service(SRV_PNPCONDITIONEVAL, PNPCondition, handle_PNPConditionEval)
 
     # Service which returns value of condition
-    rospy.Service(SRV_PNPCONDITIONVALUE,
-                  PNPConditionValue,
-                  handle_PNPConditionValue)
+    rospy.Service(SRV_PNPCONDITIONVALUE, PNPConditionValue, handle_PNPConditionValue)
 
     PNPActionServer("PNP")
 

--- a/PNPros/ROS_bridge/pnp_ros/scripts/pnp_cmd_base.py
+++ b/PNPros/ROS_bridge/pnp_ros/scripts/pnp_cmd_base.py
@@ -20,7 +20,9 @@ class tcol:
     BOLD = "\033[1m"
     UNDERLINE = "\033[4m"
 
-debug_actions_path = "debug_config.yaml"
+
+debug_actions_path = "lcastor_actions/debug_config.yaml"
+
 
 class PNPCmd_Base(object):
 
@@ -81,6 +83,8 @@ class PNPCmd_Base(object):
 
     def get_debug_actions(self, debug_config_path):
         if not os.path.exists(debug_config_path):
+            print("[DEBUG] file was not found.")
+            print("[DEBUG] current path: ", os.getcwd())
             return {"Debug": False, "msg": "Debug file was not found.", "value": {}}
 
         with open(debug_config_path) as f:
@@ -122,7 +126,11 @@ class PNPCmd_Base(object):
             }
 
         # if no actions are found
-        return {"Debug": False, "msg": "Debug mode did not find any actions.", "value": {}}
+        return {
+            "Debug": False,
+            "msg": "Debug mode did not find any actions.",
+            "value": {},
+        }
 
     def is_debug_action(self, action):
         debug_actions = self.get_debug_actions(debug_actions_path)
@@ -136,37 +144,41 @@ class PNPCmd_Base(object):
 
         if type == "enable":
             if action in actions:
-                return {'type': type, 'mode':mode, 'perform_action': True}
-            return {'type': type, 'mode': mode, 'perform_action': False}
+                return {"type": type, "mode": mode, "perform_action": True}
+            return {"type": type, "mode": mode, "perform_action": False}
 
         if type == "disable":
             if action not in actions:
-                return {'type': type, 'mode': mode, 'perform_action': True}
-            return {'type': type, 'mode':mode, 'perform_action': False}
-        
-        print('Error: Debug mode type not found enable or disable')
+                return {"type": type, "mode": mode, "perform_action": True}
+            return {"type": type, "mode": mode, "perform_action": False}
+
+        print("Error: Debug mode type not found enable or disable")
         return None
-    
+
     def check_action_is_debug_disabled(self, action) -> bool:
         debug_status = self.is_debug_action(action)
+        print(f"[DEBUG] status: {debug_status}")
         if debug_status is not None:
             if debug_status["perform_action"] is False:
-                print(f'Debug mode ({debug_status["mode"]}): action {action} is disabled')
+                print(
+                    f'[DEBUG] mode ({debug_status["mode"]}): action {action} is disabled'
+                )
                 ## RUN ACTION
                 return True
             if debug_status["perform_action"] is True:
-                print(f'Debug mode ({debug_status["mode"]}): action {action} is enabled')
-                return False 
-        return False 
-
+                print(
+                    f'[DEBUG] mode ({debug_status["mode"]}): action {action} is enabled'
+                )
+                return False
+        return False
 
     def exec_action(self, action, params, interrupt="", recovery=""):
         self.printindent()
         print("%sExec: %s %s %s" % (tcol.OKGREEN, action, params, tcol.ENDC))
 
         debug_mode = self.check_action_is_debug_disabled(action)
-        print(f'Debug mode check in exec_action {debug_mode}')
-        
+        print(f"Debug mode check in exec_action {debug_mode}")
+
         run = True
 
         # add the ER
@@ -291,4 +303,3 @@ class PNPCmd_Base(object):
 
     def plan_status(self):
         return "no status"
-

--- a/PNPros/ROS_bridge/pnp_ros/scripts/pnp_cmd_base.py
+++ b/PNPros/ROS_bridge/pnp_ros/scripts/pnp_cmd_base.py
@@ -83,8 +83,10 @@ class PNPCmd_Base(object):
 
     def get_debug_actions(self, debug_config_path):
         if not os.path.exists(debug_config_path):
-            print("[DEBUG] file was not found.")
-            print("[DEBUG] current path: ", os.getcwd())
+            print("%s[DEBUG] file was not found.%s" % (tcol.OKBLUE, tcol.ENDC))
+            print(
+                "%s[DEBUG] current path: %s%s" % (tcol.OKBLUE, os.getcwd(), tcol.ENDC)
+            )
             return {"Debug": False, "msg": "Debug file was not found.", "value": {}}
 
         with open(debug_config_path) as f:
@@ -152,22 +154,23 @@ class PNPCmd_Base(object):
                 return {"type": type, "mode": mode, "perform_action": True}
             return {"type": type, "mode": mode, "perform_action": False}
 
-        print("Error: Debug mode type not found enable or disable")
+        print("%s%s%s" % (tcol.OKBLUE, "Debug mode check in exec_action", tcol.ENDC))
         return None
 
     def check_action_is_debug_disabled(self, action) -> bool:
         debug_status = self.is_debug_action(action)
-        print(f"[DEBUG] status: {debug_status}")
+        print("%s[DEBUG] status: %s%s" % (tcol.OKBLUE, debug_status, tcol.ENDC))
         if debug_status is not None:
             if debug_status["perform_action"] is False:
                 print(
-                    f'[DEBUG] mode ({debug_status["mode"]}): action {action} is disabled'
+                    "%s[DEBUG] mode (%s): action %s is disabled%s"
+                    % (tcol.OKBLUE, debug_status["mode"], action, tcol.ENDC)
                 )
-                ## RUN ACTION
                 return True
             if debug_status["perform_action"] is True:
                 print(
-                    f'[DEBUG] mode ({debug_status["mode"]}): action {action} is enabled'
+                    "%s[DEBUG] mode (%s): action %s is enabled%s"
+                    % (tcol.OKBLUE, debug_status["mode"], action, tcol.ENDC)
                 )
                 return False
         return False
@@ -177,7 +180,12 @@ class PNPCmd_Base(object):
         print("%sExec: %s %s %s" % (tcol.OKGREEN, action, params, tcol.ENDC))
 
         debug_mode = self.check_action_is_debug_disabled(action)
-        print(f"Debug mode check in exec_action {debug_mode}")
+        print(
+            "%sDebug mode check in exec_action %s%s"
+            % (tcol.WARNING, debug_mode, tcol.ENDC)
+        )
+        if debug_mode:
+            return print('[DEBUG] PREVENTING ACTION')
 
         run = True
 

--- a/PNPros/ROS_bridge/pnp_ros/scripts/pnp_cmd_base.py
+++ b/PNPros/ROS_bridge/pnp_ros/scripts/pnp_cmd_base.py
@@ -181,11 +181,12 @@ class PNPCmd_Base(object):
 
         debug_mode = self.check_action_is_debug_disabled(action)
         print(
-            "%sDebug mode check in exec_action %s%s"
-            % (tcol.WARNING, debug_mode, tcol.ENDC)
+            "%s[DEBUG] mode check in exec_action %s%s"
+            % (tcol.OKBLUE, debug_mode, tcol.ENDC)
         )
         if debug_mode:
-            return print('[DEBUG] PREVENTING ACTION')
+            return print("%s[DEBUG] Preventing Action %s%s"
+            % (tcol.OKBLUE, action, tcol.ENDC))
 
         run = True
 

--- a/PNPros/ROS_bridge/pnp_ros/scripts/pnp_cmd_base.py
+++ b/PNPros/ROS_bridge/pnp_ros/scripts/pnp_cmd_base.py
@@ -8,68 +8,67 @@ import sys
 import os
 import time
 
-class tcol:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
 
+class tcol:
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+
+debug_actions_path = "debug_config.yaml"
 
 class PNPCmd_Base(object):
 
     def __init__(self):
-        self.execlevel = 0 # pretty print
+        self.execlevel = 0  # pretty print
 
         # to store Execution Rules
         self._action_ers = {}
 
-
     def action_cmd_base(self, action, params, cmd):
         self.printindent()
-        if (cmd=='start'):
-            print("  %s%s %s -> %s%s" %(tcol.OKGREEN,action,params,cmd,tcol.ENDC))
-        elif (cmd=='interrupt'):
-            print("  %s%s %s -> %s%s" %(tcol.WARNING,action,params,cmd,tcol.ENDC))
-        elif (cmd=='end' or cmd=='success'):
-            print("  %s%s %s -> %s%s" %(tcol.OKGREEN,action,params,cmd,tcol.ENDC))
-        elif (cmd=='failure'):
-            print("  %s%s %s -> %s%s" %(tcol.FAIL,action,params,cmd,tcol.ENDC))
+        if cmd == "start":
+            print("  %s%s %s -> %s%s" % (tcol.OKGREEN, action, params, cmd, tcol.ENDC))
+        elif cmd == "interrupt":
+            print("  %s%s %s -> %s%s" % (tcol.WARNING, action, params, cmd, tcol.ENDC))
+        elif cmd == "end" or cmd == "success":
+            print("  %s%s %s -> %s%s" % (tcol.OKGREEN, action, params, cmd, tcol.ENDC))
+        elif cmd == "failure":
+            print("  %s%s %s -> %s%s" % (tcol.FAIL, action, params, cmd, tcol.ENDC))
         else:
-            print("  %s %s -> %s" %(action,params,cmd))
-        self.action_cmd(action,params,cmd)
-
+            print("  %s %s -> %s" % (action, params, cmd))
+        self.action_cmd(action, params, cmd)
 
     def action_params_split(self, astr):
         astr = astr.strip()
-        c = astr.find('_')
+        c = astr.find("_")
         if c < 0:
             action = astr
-            params = ''
+            params = ""
         else:
             action = astr[0:c]
-            params = astr[c+1:]
+            params = astr[c + 1 :]
         return [action, params]
 
-
     def execRecovery(self, recovery):
-        if recovery=='':
+        if recovery == "":
             return
-        v = recovery.split(';')
+        v = recovery.split(";")
         for i in range(len(v)):
             ap = v[i].strip()
             self.printindent()
-            print('%s-- recovery %s%s' %(tcol.WARNING,ap,tcol.ENDC))
-            if (ap=='restart_action'):
+            print("%s-- recovery %s%s" % (tcol.WARNING, ap, tcol.ENDC))
+            if ap == "restart_action":
                 return ap
-            elif (ap=='skip_action'):
+            elif ap == "skip_action":
                 return ap
-            elif (ap=='restart_plan'):
+            elif ap == "restart_plan":
                 return ap
-            elif (ap=='fail_plan'):
+            elif ap == "fail_plan":
                 return ap
             else:
                 [action, params] = self.action_params_split(ap)
@@ -77,74 +76,154 @@ class PNPCmd_Base(object):
 
     def printindent(self):
         for i in range(self.execlevel):
-            print('    ', end="")
+            print("    ", end="")
 
-    def exec_action(self, action, params, interrupt='', recovery=''):
+    def is_debug_action(self, action):
+        debug_actions = self.get_debug_actions(debug_actions_path)
+        if debug_actions["Debug"] is False:
+            return False
+
+        mode = self.debug_actions["value"]["mode"]
+        msg = self.debug_actions["msg"]
+        type = self.debug_actions["value"]["type"]
+        actions = self.debug_actions["value"]["actions"]
+
+        if type == "enable":
+            if action in actions:
+                return {'type': type, 'mode':mode, 'perform_action' = True}
+            return {'type': type, 'mode': mode, 'perform_action' = False}
+
+        if type == "disable":
+            if action in actions:
+                return {'type': type, 'mode': mode, 'perform_action' = False}
+            return {'type': type, 'mode':mode, 'perform_action' = True}
+
+
+    def get_debug_actions(debug_config_path):
+        if not os.path.exists(debug_config_path):
+            return {"Debug": False, "msg": "Debug file was not found.", "value": {}}
+
+        with open(debug_config_path) as f:
+            debug_actions = yaml.safe_load(f)
+
+        if debug_actions["Debug"]["Active"] is False:
+            return {"Debug": False, "msg": "Debug mode is not active", "value": {}}
+
+        mode = debug_actions["Debug"]["Mode"]
+        config = debug_actions["Configurations"]
+
+        if mode not in config.keys():
+            return {
+                "Debug": False,
+                "msg": "Debug mode is not found in configurations",
+                "value": {},
+            }
+
+        if "Active" in config[mode].keys() and config[mode]["Active"] is not None:
+            return {
+                "Debug": True,
+                "msg": "Debug mode active",
+                "value": {
+                    "mode": mode,
+                    "type": "enable",
+                    "actions": config[mode]["Active"],
+                },
+            }
+
+        if "Inactive" in config[mode].keys() and config[mode]["Inactive"] is not None:
+            return {
+                "Debug": True,
+                "msg": "Debug mode active",
+                "value": {
+                    "mode": mode,
+                    "type": "disable",
+                    "actions": config[mode]["Inactive"],
+                },
+            }
+
+        # if no actions are found
+        return {"Debug": False, "msg": "Debug mode did not find any actions.", "value": {}}
+
+    def exec_action(self, action, params, interrupt="", recovery=""):
         self.printindent()
-        print("%sExec: %s %s %s" %(tcol.OKGREEN,action,params,tcol.ENDC))
+        print("%sExec: %s %s %s" % (tcol.OKGREEN, action, params, tcol.ENDC))
+
+        # TODO: Check if this action is part of the debug modes
+        if action is not '':
+            print("DEBUG MODE: %s" % debug)
+            if debug not in self.debug_actions:
+                return "success"
+
+        self.debug_actions:
+        #     self.debug_action(action, params)
+        #     return r
 
         run = True
 
         # add the ER
-        if interrupt != '' and recovery != '':
+        if interrupt != "" and recovery != "":
             self.add_ER(action, interrupt, recovery)
 
-        while (run): # interrupt may restart this action
+        while run:  # interrupt may restart this action
 
-            self.action_cmd_base(action, params, 'start')
+            self.action_cmd_base(action, params, "start")
 
             # the PNP action server will change the status to running after it stated
             # the action. Therefore we wait here for that to happen.
 
-            while (self.action_status(action) == "started"):
+            while self.action_status(action) == "started":
                 time.sleep(0.1)
 
             # wait for action to terminate
-            r = 'running'
+            r = "running"
             c = False
-            while (r=='running' and not c):
+            while r == "running" and not c:
                 r = self.action_status(action)
                 # check for interrupt condition
                 c, rec = self._check_interrupt_conditions(action)
 
                 time.sleep(0.1)
-            print("   -- action status: %s, interrupt condition: %r" %(r,c))
+            print("   -- action status: %s, interrupt condition: %r" % (r, c))
             run = False  # exit
-            if (not c): # normal termination
+            if not c:  # normal termination
                 self.printindent()
                 self.action_cmd_base(action, params, r)
                 # if (r=='success'):
                 #     print("  %s%s %s -> %s%s" %(tcol.OKGREEN,action,params,r,tcol.ENDC))
                 # else:
                 #     print("  %s%s %s -> %s%s" %(tcol.FAIL,action,params,r,tcol.ENDC))
-            else: # interrupt
-                r = 'interrupt'
+            else:  # interrupt
+                r = "interrupt"
                 self.action_cmd_base(action, params, r)
-                while self.action_status(action)=='running':
+                while self.action_status(action) == "running":
                     time.sleep(0.1)
                 self.execlevel += 1
                 p_rec = self.execRecovery(rec)
                 self.execlevel -= 1
-                if p_rec=='restart_action':
+                if p_rec == "restart_action":
                     run = True
-                elif p_rec=='fail_plan':
+                elif p_rec == "fail_plan":
                     self.end()
                 else:
-                    print("[ERROR] The recovery procedure "+ p_rec + " may not be implemented. I am just stopping the current action and continuing with the plan.")
+                    print(
+                        "[ERROR] The recovery procedure "
+                        + p_rec
+                        + " may not be implemented. I am just stopping the current action and continuing with the plan."
+                    )
         return r
 
     def _check_interrupt_conditions(self, action):
         c = False
-        rec = ''
+        rec = ""
 
         if action in self._action_ers.keys():
             # print self._action_ers[action].items()
             for interrupt, recovery in self._action_ers[action].items():
-                if (interrupt[0:7].lower()=='timeout'):
+                if interrupt[0:7].lower() == "timeout":
                     now = time.time()
                     st = self.action_starttime(action)
-                    v = interrupt.split('_')
-                    #print 'timeout %f %f diff: %f > %f' %(now, st, now-st, float(v[1]) )
+                    v = interrupt.split("_")
+                    # print 'timeout %f %f diff: %f > %f' %(now, st, now-st, float(v[1]) )
                     c = (now - st) > float(v[1])
                 else:
                     c = self.get_condition(interrupt)
@@ -154,7 +233,7 @@ class PNPCmd_Base(object):
                     return c, rec
 
         # else:
-            # print "No ers for action ", action
+        # print "No ers for action ", action
         return c, rec
 
     def add_ER(self, action, interrupt, recovery):
@@ -166,9 +245,22 @@ class PNPCmd_Base(object):
         self._action_ers[action][interrupt] = recovery
 
     def plan_gen(self, planname):
-        oscmd = 'cd %s; ./genplan.sh %s.plan %s.er' % (self.plan_folder, planname, planname)
+        oscmd = "cd %s; ./genplan.sh %s.plan %s.er" % (
+            self.plan_folder,
+            planname,
+            planname,
+        )
         print(oscmd)
         os.system(oscmd)
+
+    def debug_mode_evaluation(self, debug):
+        '''Read the debug yaml file and determine if the action should run or not'''
+        # read debug_config.yaml
+        with open('debug_config.yaml', 'r') as file:
+            debug_config = yaml.load(file, Loader=yaml.FullLoader)
+        if debug_config in debug_config:
+
+        if debug is not in Mode
 
     # TO BE IMPLEMENTED BY SUBCLASSES
 
@@ -178,14 +270,14 @@ class PNPCmd_Base(object):
     def end(self):
         pass
 
-    def action_cmd(self,action,params,cmd): # non-blocking
+    def action_cmd(self, action, params, cmd):  # non-blocking
         pass
 
     def set_action_status(self, action, status):
-        return ''
+        return ""
 
     def action_status(self, action):
-        return ''
+        return ""
 
     def get_condition(self, cond):
         return False
@@ -193,11 +285,12 @@ class PNPCmd_Base(object):
     def set_condition(self, cond, value):
         return
 
-    def plan_cmd(self, planname, cmd): # non-blocking
+    def plan_cmd(self, planname, cmd):  # non-blocking
         pass
 
     def plan_name(self):
-        return 'no plan'
+        return "no plan"
 
     def plan_status(self):
-        return 'no status'
+        return "no status"
+

--- a/PNPros/ROS_bridge/pnp_ros/scripts/pnp_cmd_base.py
+++ b/PNPros/ROS_bridge/pnp_ros/scripts/pnp_cmd_base.py
@@ -21,7 +21,7 @@ class tcol:
     UNDERLINE = "\033[4m"
 
 
-debug_actions_path = "lcastor_actions/debug_config.yaml"
+debug_actions_path = "../lcastor_actions/debug_config.yaml"
 
 
 class PNPCmd_Base(object):

--- a/PNPros/ROS_bridge/pnp_ros/scripts/pnp_cmd_base.py
+++ b/PNPros/ROS_bridge/pnp_ros/scripts/pnp_cmd_base.py
@@ -262,17 +262,6 @@ class PNPCmd_Base(object):
         print(oscmd)
         os.system(oscmd)
 
-    def debug_mode_evaluation(self, debug):
-        '''Read the debug yaml file and determine if the action should run or not'''
-        # read debug_config.yaml
-        with open('debug_config.yaml', 'r') as file:
-            debug_config = yaml.load(file, Loader=yaml.FullLoader)
-        if debug_config in debug_config:
-
-        if debug is not in Mode
-
-    # TO BE IMPLEMENTED BY SUBCLASSES
-
     def begin(self):
         pass
 

--- a/PNPros/ROS_bridge/pnp_ros/scripts/pnp_cmd_ros.py
+++ b/PNPros/ROS_bridge/pnp_ros/scripts/pnp_cmd_ros.py
@@ -109,6 +109,14 @@ class PNPCmd(PNPCmd_Base):
         os._exit(os.EX_OK)
 
     def action_cmd(self,action,params,cmd):
+        debug_mode = self.check_action_is_debug_disabled(action)
+        print(
+            "%sDebug mode check in action_cmd %s%s"
+            % (tcol.WARNING, debug_mode, tcol.ENDC)
+        )
+        if debug_mode:
+            return print('[DEBUG] PREVENTING ACTION')
+
         if (cmd=='stop' or cmd=='interrupt'):
             cmd = 'interrupt'
             if action in self._current_actions.keys():

--- a/PNPros/ROS_bridge/pnp_ros/scripts/pnp_cmd_ros.py
+++ b/PNPros/ROS_bridge/pnp_ros/scripts/pnp_cmd_ros.py
@@ -111,11 +111,12 @@ class PNPCmd(PNPCmd_Base):
     def action_cmd(self,action,params,cmd):
         debug_mode = self.check_action_is_debug_disabled(action)
         print(
-            "%sDebug mode check in action_cmd %s%s"
-            % (tcol.WARNING, debug_mode, tcol.ENDC)
+            "%s[DEBUG] mode check in action_cmd %s%s"
+            % (tcol.OKBLUE, debug_mode, tcol.ENDC)
         )
         if debug_mode:
-            return print('[DEBUG] PREVENTING ACTION')
+            return print("%s[DEBUG] Preventing Action %s%s"
+            % (tcol.OKBLUE, action, tcol.ENDC))
 
         if (cmd=='stop' or cmd=='interrupt'):
             cmd = 'interrupt'

--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ At this point, every time PNP receives an event of the form GoTo_instance1_insta
 From this point on, the global variables can be used in the plan (for example in execution nodes, such as in a node called "GoTo_@X_@Y_@Theta.exec").
 
 Finally, to modify the variables' value just reinstantiate them as previously explained.
+
+Test commit


### PR DESCRIPTION
This PR primarily makes changes to `PNPros/ROS_bridge/pnp_ros/scripts/pnp_cmd_base.py` to allow custom debug configurations to be created and run on the fly.

As of now, the debug file should be named `debug_config.yaml` located in the `lcastor_actions` folder.  an example configurations can be seen below.

..my apologies for all the auto linter changes.. 

TODO: 
- [ ] improve how the location of the file is identified
- [ ] clean up the debug prints
- [ ] improve how the data is passed through the functions
- [ ] possibly move the functions from the `.._cmd_base` file to the `..cmd_ros` file instead

<details>
  <summary>debug_config.yaml sample template</summary>
  
`LCASTOR/lcastor_actions/debug_config.yaml`
```yaml
Debug: 
  Active: true
  Mode: "Test" # default 'off' 

Configurations:
  # Modes should have either an Active or Inactive list
  # Active actions are the actions that are enabled in the mode
  # Inactive actions are the actions that are disabled in the mode
  # If BOTH are present, ONLY the Active list will be used
  Test: # name of the mode
    Active:
      # activateRasa
      # armAction
      # debug_config
      # findClosestPersonToTrack
      # followPerson
      # followPerson_ats
      # gestureDetection
      # getContinueConfirmation
      # getTextInput
      # getYesNoConfirmation
      # goto
      # gotoRoom
      # gotoRoom
      # graspObject
      # gripperAction
      # listen
      # lookAtClosestPerson
      # moveGripperTo
      moveHead
      # moveTorso
      # navigateForward
      # objectDetection
      # peopleDetection
      # personIdentification
      # recog_action
      # saveGuestData
      # setNavigationMode
      speak
      # test
      # waitOpenDoor
```
</details>
